### PR TITLE
Disable HadoopFileIO usage in DefaultFileIOFactory

### DIFF
--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -71,10 +71,12 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
               .defaultValue(true)
               .buildBehaviorChangeConfiguration();
 
-  public static final BehaviorChangeConfiguration<Boolean> DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO =
-      PolarisConfiguration.<Boolean>builder()
-          .key("DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO")
-          .description("Whether or not to disable the use of HadoopFileIO inside the default FileIOFactory")
-          .defaultValue(true)
-          .buildBehaviorChangeConfiguration();
+  public static final BehaviorChangeConfiguration<Boolean>
+      DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO =
+          PolarisConfiguration.<Boolean>builder()
+              .key("DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO")
+              .description(
+                  "Whether or not to disable the use of HadoopFileIO inside the default FileIOFactory")
+              .defaultValue(false)
+              .buildBehaviorChangeConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -70,4 +70,11 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
                       + " the committed metadata again.")
               .defaultValue(true)
               .buildBehaviorChangeConfiguration();
+
+  public static final BehaviorChangeConfiguration<Boolean> DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO =
+      PolarisConfiguration.<Boolean>builder()
+          .key("DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO")
+          .description("Whether or not to disable the use of HadoopFileIO inside the default FileIOFactory")
+          .defaultValue(true)
+          .buildBehaviorChangeConfiguration();
 }

--- a/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
+++ b/polaris-core/src/main/java/org/apache/polaris/core/config/BehaviorChangeConfiguration.java
@@ -70,13 +70,4 @@ public class BehaviorChangeConfiguration<T> extends PolarisConfiguration<T> {
                       + " the committed metadata again.")
               .defaultValue(true)
               .buildBehaviorChangeConfiguration();
-
-  public static final BehaviorChangeConfiguration<Boolean>
-      DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO =
-          PolarisConfiguration.<Boolean>builder()
-              .key("DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO")
-              .description(
-                  "Whether or not to disable the use of HadoopFileIO inside the default FileIOFactory")
-              .defaultValue(false)
-              .buildBehaviorChangeConfiguration();
 }

--- a/quarkus/defaults/src/main/resources/application.properties
+++ b/quarkus/defaults/src/main/resources/application.properties
@@ -123,6 +123,7 @@ polaris.persistence.type=in-memory
 polaris.secrets-manager.type=in-memory
 
 polaris.file-io.type=default
+polaris.file-io.default-config.allow-hadoop-file-io=false
 
 polaris.event-listener.type=no-op
 

--- a/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/catalog/io/QuarkusFileIOConfiguration.java
+++ b/quarkus/service/src/main/java/org/apache/polaris/service/quarkus/catalog/io/QuarkusFileIOConfiguration.java
@@ -21,9 +21,5 @@ package org.apache.polaris.service.quarkus.catalog.io;
 import io.smallrye.config.ConfigMapping;
 import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 
-import java.util.Optional;
-
 @ConfigMapping(prefix = "polaris.file-io")
-public interface QuarkusFileIOConfiguration extends FileIOConfiguration {
-
-}
+public interface QuarkusFileIOConfiguration extends FileIOConfiguration {}

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -74,6 +74,7 @@ import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.service.TestFileIOConfiguration;
 import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.generic.GenericTableCatalog;
@@ -242,7 +243,7 @@ public class GenericTableCatalogTest {
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     this.fileIOFactory =
         new DefaultFileIOFactory(
             realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -244,7 +244,8 @@ public class GenericTableCatalogTest {
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
     FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     this.fileIOFactory =
-        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
+        new DefaultFileIOFactory(
+            realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
 
     StsClient stsClient = Mockito.mock(StsClient.class);
     when(stsClient.assumeRole(isA(AssumeRoleRequest.class)))

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -79,6 +79,7 @@ import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.generic.GenericTableCatalog;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.config.ReservedProperties;
@@ -241,8 +242,9 @@ public class GenericTableCatalogTest {
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     this.fileIOFactory =
-        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore);
+        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
 
     StsClient stsClient = Mockito.mock(StsClient.class);
     when(stsClient.assumeRole(isA(AssumeRoleRequest.class)))

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/GenericTableCatalogTest.java
@@ -242,7 +242,7 @@ public class GenericTableCatalogTest {
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     this.fileIOFactory =
         new DefaultFileIOFactory(
             realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -1800,7 +1800,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
     validatePayload.setTimestamp(530950845L);
     validateRequest.setPayload(validatePayload);
 
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     PolarisCallContextCatalogFactory factory =
         new PolarisCallContextCatalogFactory(
             new RealmEntityManagerFactory(null) {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -65,6 +65,7 @@ import org.apache.polaris.core.entity.PrincipalEntity;
 import org.apache.polaris.core.persistence.PolarisEntityManager;
 import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
+import org.apache.polaris.service.TestFileIOConfiguration;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandler;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
 import org.apache.polaris.service.catalog.io.FileIOConfiguration;
@@ -1800,7 +1801,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
     validatePayload.setTimestamp(530950845L);
     validateRequest.setPayload(validatePayload);
 
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     PolarisCallContextCatalogFactory factory =
         new PolarisCallContextCatalogFactory(
             new RealmEntityManagerFactory(null) {

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -67,6 +67,7 @@ import org.apache.polaris.core.persistence.dao.entity.CreatePrincipalResult;
 import org.apache.polaris.core.persistence.resolver.PolarisResolutionManifest;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalogHandler;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.context.CallContextCatalogFactory;
 import org.apache.polaris.service.context.PolarisCallContextCatalogFactory;
@@ -1799,6 +1800,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
     validatePayload.setTimestamp(530950845L);
     validateRequest.setPayload(validatePayload);
 
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     PolarisCallContextCatalogFactory factory =
         new PolarisCallContextCatalogFactory(
             new RealmEntityManagerFactory(null) {
@@ -1811,7 +1813,7 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
             userSecretsManagerFactory,
             Mockito.mock(),
             new DefaultFileIOFactory(
-                realmEntityManagerFactory, managerFactory, new PolarisConfigurationStore() {}),
+                realmEntityManagerFactory, managerFactory, new PolarisConfigurationStore() {}, fileIOConfiguration),
             polarisEventListener) {
           @Override
           public Catalog createCallContextCatalog(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogHandlerAuthzTest.java
@@ -1813,7 +1813,10 @@ public class IcebergCatalogHandlerAuthzTest extends PolarisAuthzTestBase {
             userSecretsManagerFactory,
             Mockito.mock(),
             new DefaultFileIOFactory(
-                realmEntityManagerFactory, managerFactory, new PolarisConfigurationStore() {}, fileIOConfiguration),
+                realmEntityManagerFactory,
+                managerFactory,
+                new PolarisConfigurationStore() {},
+                fileIOConfiguration),
             polarisEventListener) {
           @Override
           public Catalog createCallContextCatalog(

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -315,7 +315,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     this.fileIOFactory =
         new DefaultFileIOFactory(
             realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
@@ -656,7 +656,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, catalog().name());
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     FileIOFactory fileIOFactory =
         spy(
             new DefaultFileIOFactory(
@@ -1575,7 +1575,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         .containsEntry(StorageAccessProperty.AWS_SECRET_KEY, SECRET_ACCESS_KEY)
         .containsEntry(StorageAccessProperty.AWS_TOKEN, SESSION_TOKEN);
     MetaStoreManagerFactory metaStoreManagerFactory = createMockMetaStoreManagerFactory();
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     FileIO fileIO =
         new TaskFileIOSupplier(
                 new DefaultFileIOFactory(
@@ -1722,7 +1722,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, CATALOG_NAME);
 
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     MeasuredFileIOFactory measured =
         new MeasuredFileIOFactory(
             new RealmEntityManagerFactory(createMockMetaStoreManagerFactory()),

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -109,6 +109,7 @@ import org.apache.polaris.core.storage.StorageAccessProperty;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.service.TestFileIOConfiguration;
 import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
@@ -315,7 +316,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     this.fileIOFactory =
         new DefaultFileIOFactory(
             realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
@@ -656,7 +657,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, catalog().name());
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     FileIOFactory fileIOFactory =
         spy(
             new DefaultFileIOFactory(
@@ -1575,7 +1576,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         .containsEntry(StorageAccessProperty.AWS_SECRET_KEY, SECRET_ACCESS_KEY)
         .containsEntry(StorageAccessProperty.AWS_TOKEN, SESSION_TOKEN);
     MetaStoreManagerFactory metaStoreManagerFactory = createMockMetaStoreManagerFactory();
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     FileIO fileIO =
         new TaskFileIOSupplier(
                 new DefaultFileIOFactory(
@@ -1722,7 +1723,7 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, CATALOG_NAME);
 
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     MeasuredFileIOFactory measured =
         new MeasuredFileIOFactory(
             new RealmEntityManagerFactory(createMockMetaStoreManagerFactory()),

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -114,6 +114,7 @@ import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
 import org.apache.polaris.service.catalog.io.ExceptionMappingFileIO;
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
@@ -314,8 +315,9 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
 
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     this.fileIOFactory =
-        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore);
+        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
 
     StsClient stsClient = Mockito.mock(StsClient.class);
     when(stsClient.assumeRole(isA(AssumeRoleRequest.class)))
@@ -653,12 +655,14 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, catalog().name());
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     FileIOFactory fileIOFactory =
         spy(
             new DefaultFileIOFactory(
                 new RealmEntityManagerFactory(createMockMetaStoreManagerFactory()),
                 managerFactory,
-                configurationStore));
+                configurationStore,
+                fileIOConfiguration));
     IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,
@@ -1570,12 +1574,14 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         .containsEntry(StorageAccessProperty.AWS_SECRET_KEY, SECRET_ACCESS_KEY)
         .containsEntry(StorageAccessProperty.AWS_TOKEN, SESSION_TOKEN);
     MetaStoreManagerFactory metaStoreManagerFactory = createMockMetaStoreManagerFactory();
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     FileIO fileIO =
         new TaskFileIOSupplier(
                 new DefaultFileIOFactory(
                     new RealmEntityManagerFactory(metaStoreManagerFactory),
                     metaStoreManagerFactory,
-                    configurationStore))
+                    configurationStore,
+                    fileIOConfiguration))
             .apply(taskEntity, callContext);
     Assertions.assertThat(fileIO).isNotNull().isInstanceOf(ExceptionMappingFileIO.class);
     Assertions.assertThat(((ExceptionMappingFileIO) fileIO).getInnerIo())
@@ -1715,11 +1721,13 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, CATALOG_NAME);
 
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     MeasuredFileIOFactory measured =
         new MeasuredFileIOFactory(
             new RealmEntityManagerFactory(createMockMetaStoreManagerFactory()),
             managerFactory,
-            configurationStore);
+            configurationStore,
+            fileIOConfiguration);
     IcebergCatalog catalog =
         new IcebergCatalog(
             entityManager,

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogTest.java
@@ -317,7 +317,8 @@ public abstract class IcebergCatalogTest extends CatalogTests<IcebergCatalog> {
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
     FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     this.fileIOFactory =
-        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
+        new DefaultFileIOFactory(
+            realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
 
     StsClient stsClient = Mockito.mock(StsClient.class);
     when(stsClient.assumeRole(isA(AssumeRoleRequest.class)))

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -66,6 +66,7 @@ import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.config.ReservedProperties;
@@ -229,9 +230,10 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, CATALOG_NAME);
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     FileIOFactory fileIOFactory =
         new DefaultFileIOFactory(
-            new RealmEntityManagerFactory(managerFactory), managerFactory, configurationStore);
+            new RealmEntityManagerFactory(managerFactory), managerFactory, configurationStore, fileIOConfiguration);
 
     testPolarisEventListener = (TestPolarisEventListener) polarisEventListener;
     this.catalog =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -62,6 +62,7 @@ import org.apache.polaris.core.persistence.cache.InMemoryEntityCache;
 import org.apache.polaris.core.secrets.UserSecretsManager;
 import org.apache.polaris.core.secrets.UserSecretsManagerFactory;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.service.TestFileIOConfiguration;
 import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
@@ -230,7 +231,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, CATALOG_NAME);
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     FileIOFactory fileIOFactory =
         new DefaultFileIOFactory(
             new RealmEntityManagerFactory(managerFactory),

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -230,7 +230,7 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
     PolarisPassthroughResolutionView passthroughView =
         new PolarisPassthroughResolutionView(
             callContext, entityManager, securityContext, CATALOG_NAME);
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     FileIOFactory fileIOFactory =
         new DefaultFileIOFactory(
             new RealmEntityManagerFactory(managerFactory),

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/IcebergCatalogViewTest.java
@@ -233,7 +233,10 @@ public class IcebergCatalogViewTest extends ViewCatalogTests<IcebergCatalog> {
     FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     FileIOFactory fileIOFactory =
         new DefaultFileIOFactory(
-            new RealmEntityManagerFactory(managerFactory), managerFactory, configurationStore, fileIOConfiguration);
+            new RealmEntityManagerFactory(managerFactory),
+            managerFactory,
+            configurationStore,
+            fileIOConfiguration);
 
     testPolarisEventListener = (TestPolarisEventListener) polarisEventListener;
     this.catalog =

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -91,6 +91,7 @@ import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
 import org.apache.polaris.service.catalog.io.DefaultFileIOFactory;
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
 import org.apache.polaris.service.catalog.policy.PolicyCatalog;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
@@ -265,8 +266,9 @@ public class PolicyCatalogTest {
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
+    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     this.fileIOFactory =
-        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore);
+        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
 
     StsClient stsClient = Mockito.mock(StsClient.class);
     when(stsClient.assumeRole(isA(AssumeRoleRequest.class)))

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -266,7 +266,7 @@ public class PolicyCatalogTest {
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
-    FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
+    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
     this.fileIOFactory =
         new DefaultFileIOFactory(
             realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -268,7 +268,8 @@ public class PolicyCatalogTest {
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
     FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
     this.fileIOFactory =
-        new DefaultFileIOFactory(realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
+        new DefaultFileIOFactory(
+            realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);
 
     StsClient stsClient = Mockito.mock(StsClient.class);
     when(stsClient.assumeRole(isA(AssumeRoleRequest.class)))

--- a/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
+++ b/quarkus/service/src/test/java/org/apache/polaris/service/quarkus/catalog/PolicyCatalogTest.java
@@ -87,6 +87,7 @@ import org.apache.polaris.core.storage.PolarisStorageIntegrationProvider;
 import org.apache.polaris.core.storage.aws.AwsCredentialsStorageIntegration;
 import org.apache.polaris.core.storage.aws.AwsStorageConfigurationInfo;
 import org.apache.polaris.core.storage.cache.StorageCredentialCache;
+import org.apache.polaris.service.TestFileIOConfiguration;
 import org.apache.polaris.service.admin.PolarisAdminService;
 import org.apache.polaris.service.catalog.PolarisPassthroughResolutionView;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalog;
@@ -266,7 +267,7 @@ public class PolicyCatalogTest {
     TaskExecutor taskExecutor = Mockito.mock();
     RealmEntityManagerFactory realmEntityManagerFactory =
         new RealmEntityManagerFactory(createMockMetaStoreManagerFactory());
-    FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+    FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
     this.fileIOFactory =
         new DefaultFileIOFactory(
             realmEntityManagerFactory, managerFactory, configurationStore, fileIOConfiguration);

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.polaris.core.config.PolarisConfigurationStore;
 import org.apache.polaris.core.context.CallContext;
@@ -116,7 +117,12 @@ public class DefaultFileIOFactory implements FileIOFactory {
   @VisibleForTesting
   FileIO loadFileIOInternal(
       @Nonnull String ioImplClassName, @Nonnull Map<String, String> properties) {
-    return new ExceptionMappingFileIO(
-        CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration()));
+    FileIO innerFileIO = CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration());
+    if (innerFileIO instanceof HadoopFileIO) {
+      if (false) {
+        throw new IllegalStateException("Hadoop FileIO implementation disabled by the service");
+      }
+    }
+    return new ExceptionMappingFileIO(innerFileIO);
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -124,9 +124,10 @@ public class DefaultFileIOFactory implements FileIOFactory {
       @Nonnull Set<String> tableLocations) {
     FileIO innerFileIO = CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration());
 
-    boolean prohibitHadoopFileIO = configurationStore.getConfiguration(
-        callContext.getPolarisCallContext(),
-        BehaviorChangeConfiguration.DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO);
+    boolean prohibitHadoopFileIO =
+        configurationStore.getConfiguration(
+            callContext.getPolarisCallContext(),
+            BehaviorChangeConfiguration.DEFAULT_FILE_IO_FACTORY_DISABLE_HADOOP_FILE_IO);
 
     if (prohibitHadoopFileIO) {
       boolean isHadoopFileIO = innerFileIO instanceof HadoopFileIO;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/DefaultFileIOFactory.java
@@ -126,11 +126,11 @@ public class DefaultFileIOFactory implements FileIOFactory {
       @Nonnull Set<String> tableLocations) {
     FileIO innerFileIO = CatalogUtil.loadFileIO(ioImplClassName, properties, new Configuration());
 
-    boolean prohibitHadoopFileIO = Optional
-        .ofNullable(fileIOConfiguration.defaultConfig())
-        .map(FileIOConfiguration.DefaultFileIOConfig::allowHadoopFileIO)
-        .flatMap(c -> c)
-        .orElse(false);
+    boolean prohibitHadoopFileIO =
+        Optional.ofNullable(fileIOConfiguration.defaultConfig())
+            .map(FileIOConfiguration.DefaultFileIOConfig::allowHadoopFileIO)
+            .flatMap(c -> c)
+            .orElse(false);
 
     if (prohibitHadoopFileIO) {
       boolean isHadoopFileIO = innerFileIO instanceof HadoopFileIO;

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
@@ -26,13 +26,21 @@ public interface FileIOConfiguration {
    * The type of the catalog IO to use. Must be a registered {@link
    * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
    */
-  String type();
+  default String type() {
+    return "default";
+  }
 
   /** Configurations for the DefaultFileIOFactory */
-  DefaultFileIOConfig defaultConfig();
+  default DefaultFileIOConfig defaultConfig() {
+    return new DefaultFileIOConfig() {
+
+    };
+  }
 
   interface DefaultFileIOConfig {
     /** Whether to disable the use of HadoopFileIO inside the default FileIOFactory */
-    Optional<Boolean> allowHadoopFileIO();
+    default Optional<Boolean> allowHadoopFileIO() {
+      return Optional.of(false);
+    }
   }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
@@ -16,14 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.quarkus.catalog.io;
 
-import io.smallrye.config.ConfigMapping;
-import org.apache.polaris.service.catalog.io.FileIOConfiguration;
+package org.apache.polaris.service.catalog.io;
 
 import java.util.Optional;
 
-@ConfigMapping(prefix = "polaris.file-io")
-public interface QuarkusFileIOConfiguration extends FileIOConfiguration {
+public interface FileIOConfiguration {
 
+    /**
+     * The type of the catalog IO to use. Must be a registered {@link
+     * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
+     */
+    String type();
+
+    /** Configurations for the DefaultFileIOFactory */
+    DefaultFileIOConfig defaultConfig();
+
+    interface DefaultFileIOConfig {
+        /**
+         * Whether to disable the use of HadoopFileIO inside the default FileIOFactory
+         */
+        Optional<Boolean> allowHadoopFileIO();
+    }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
@@ -16,26 +16,23 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service.catalog.io;
 
 import java.util.Optional;
 
 public interface FileIOConfiguration {
 
-    /**
-     * The type of the catalog IO to use. Must be a registered {@link
-     * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
-     */
-    String type();
+  /**
+   * The type of the catalog IO to use. Must be a registered {@link
+   * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
+   */
+  String type();
 
-    /** Configurations for the DefaultFileIOFactory */
-    DefaultFileIOConfig defaultConfig();
+  /** Configurations for the DefaultFileIOFactory */
+  DefaultFileIOConfig defaultConfig();
 
-    interface DefaultFileIOConfig {
-        /**
-         * Whether to disable the use of HadoopFileIO inside the default FileIOFactory
-         */
-        Optional<Boolean> allowHadoopFileIO();
-    }
+  interface DefaultFileIOConfig {
+    /** Whether to disable the use of HadoopFileIO inside the default FileIOFactory */
+    Optional<Boolean> allowHadoopFileIO();
+  }
 }

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/FileIOConfiguration.java
@@ -32,9 +32,7 @@ public interface FileIOConfiguration {
 
   /** Configurations for the DefaultFileIOFactory */
   default DefaultFileIOConfig defaultConfig() {
-    return new DefaultFileIOConfig() {
-
-    };
+    return new DefaultFileIOConfig() {};
   }
 
   interface DefaultFileIOConfig {

--- a/service/common/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
+++ b/service/common/src/main/java/org/apache/polaris/service/catalog/io/WasbTranslatingFileIOFactory.java
@@ -44,10 +44,14 @@ public class WasbTranslatingFileIOFactory implements FileIOFactory {
   public WasbTranslatingFileIOFactory(
       RealmEntityManagerFactory realmEntityManagerFactory,
       MetaStoreManagerFactory metaStoreManagerFactory,
-      PolarisConfigurationStore configurationStore) {
+      PolarisConfigurationStore configurationStore,
+      FileIOConfiguration fileIOConfiguration) {
     defaultFileIOFactory =
         new DefaultFileIOFactory(
-            realmEntityManagerFactory, metaStoreManagerFactory, configurationStore);
+            realmEntityManagerFactory,
+            metaStoreManagerFactory,
+            configurationStore,
+            fileIOConfiguration);
   }
 
   @Override

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -29,6 +29,8 @@ import java.time.Clock;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -109,13 +111,16 @@ public class FileIOFactoryTest {
                     entityManagerFactory, metaStoreManagerFactory, configurationStore) {
                   @Override
                   FileIO loadFileIOInternal(
-                      @Nonnull String ioImplClassName, @Nonnull Map<String, String> properties) {
+                      @Nonnull String ioImplClassName,
+                      @Nonnull Map<String, String> properties,
+                      @Nonnull CallContext callContext,
+                      @Nonnull Set<String> tableLocations) {
                     // properties should contain credentials
                     Assertions.assertThat(properties)
                         .containsEntry(S3FileIOProperties.ACCESS_KEY_ID, TEST_ACCESS_KEY)
                         .containsEntry(S3FileIOProperties.SECRET_ACCESS_KEY, SECRET_ACCESS_KEY)
                         .containsEntry(S3FileIOProperties.SESSION_TOKEN, SESSION_TOKEN);
-                    return super.loadFileIOInternal(ioImplClassName, properties);
+                    return super.loadFileIOInternal(ioImplClassName, properties, callContext, tableLocations);
                   }
                 });
 

--- a/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
+++ b/service/common/src/test/java/org/apache/polaris/service/catalog/io/FileIOFactoryTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
@@ -120,7 +119,8 @@ public class FileIOFactoryTest {
                         .containsEntry(S3FileIOProperties.ACCESS_KEY_ID, TEST_ACCESS_KEY)
                         .containsEntry(S3FileIOProperties.SECRET_ACCESS_KEY, SECRET_ACCESS_KEY)
                         .containsEntry(S3FileIOProperties.SESSION_TOKEN, SESSION_TOKEN);
-                    return super.loadFileIOInternal(ioImplClassName, properties, callContext, tableLocations);
+                    return super.loadFileIOInternal(
+                        ioImplClassName, properties, callContext, tableLocations);
                   }
                 });
 

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestFileIOConfiguration.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestFileIOConfiguration.java
@@ -16,23 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.polaris.service.catalog.io;
+
+package org.apache.polaris.service;
+
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 
 import java.util.Optional;
 
-public interface FileIOConfiguration {
+public interface TestFileIOConfiguration extends FileIOConfiguration {
 
-  /**
-   * The type of the catalog IO to use. Must be a registered {@link
-   * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
-   */
-  String type();
+    /**
+     * The type of the catalog IO to use. Must be a registered {@link
+     * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
+     */
+    @Override
+    default String type() {
+        return "default";
+    }
 
-  /** Configurations for the DefaultFileIOFactory */
-  DefaultFileIOConfig defaultConfig();
-
-  interface DefaultFileIOConfig {
-    /** Whether to disable the use of HadoopFileIO inside the default FileIOFactory */
-    Optional<Boolean> allowHadoopFileIO();
-  }
+    /** Configurations for the DefaultFileIOFactory */
+    @Override
+    default org.apache.polaris.service.catalog.io.FileIOConfiguration.DefaultFileIOConfig defaultConfig() {
+        return new DefaultFileIOConfig() {
+            @Override
+            public Optional<Boolean> allowHadoopFileIO() {
+                return Optional.of(false);
+            }
+        };
+    }
 }

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestFileIOConfiguration.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestFileIOConfiguration.java
@@ -16,32 +16,32 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
 package org.apache.polaris.service;
 
-import org.apache.polaris.service.catalog.io.FileIOConfiguration;
-
 import java.util.Optional;
+import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 
 public interface TestFileIOConfiguration extends FileIOConfiguration {
 
-    /**
-     * The type of the catalog IO to use. Must be a registered {@link
-     * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
-     */
-    @Override
-    default String type() {
-        return "default";
-    }
+  /**
+   * The type of the catalog IO to use. Must be a registered {@link
+   * org.apache.polaris.service.catalog.io.FileIOFactory} identifier.
+   */
+  @Override
+  default String type() {
+    return "default";
+  }
 
-    /** Configurations for the DefaultFileIOFactory */
-    @Override
-    default org.apache.polaris.service.catalog.io.FileIOConfiguration.DefaultFileIOConfig defaultConfig() {
-        return new DefaultFileIOConfig() {
-            @Override
-            public Optional<Boolean> allowHadoopFileIO() {
-                return Optional.of(false);
-            }
-        };
-    }
+  /** Configurations for the DefaultFileIOFactory */
+  @Override
+  default org.apache.polaris.service.catalog.io.FileIOConfiguration.DefaultFileIOConfig
+      defaultConfig() {
+    return new DefaultFileIOConfig() {
+      /** For testing, we will use the HadoopFileIO for FILE storage type */
+      @Override
+      public Optional<Boolean> allowHadoopFileIO() {
+        return Optional.of(true);
+      }
+    };
+  }
 }

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -52,6 +52,7 @@ import org.apache.polaris.service.catalog.api.IcebergRestConfigurationApi;
 import org.apache.polaris.service.catalog.iceberg.IcebergCatalogAdapter;
 import org.apache.polaris.service.catalog.io.FileIOConfiguration;
 import org.apache.polaris.service.catalog.io.FileIOFactory;
+import org.apache.polaris.service.catalog.io.MeasuredFileIOFactory;
 import org.apache.polaris.service.config.DefaultConfigurationStore;
 import org.apache.polaris.service.config.RealmEntityManagerFactory;
 import org.apache.polaris.service.config.ReservedProperties;
@@ -99,7 +100,7 @@ public record TestServices(
     private RealmContext realmContext = TEST_REALM;
     private Map<String, Object> config = Map.of();
     private StsClient stsClient = Mockito.mock(StsClient.class);
-    private FileIOFactorySupplier fileIOFactorySupplier;
+    private FileIOFactorySupplier fileIOFactorySupplier = MeasuredFileIOFactory::new;
 
     private Builder() {}
 

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -27,7 +27,6 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.polaris.core.PolarisCallContext;
 import org.apache.polaris.core.PolarisDiagnostics;
@@ -127,7 +128,6 @@ public record TestServices(
       DefaultConfigurationStore configurationStore = new DefaultConfigurationStore(config);
       PolarisDiagnostics polarisDiagnostics = Mockito.mock(PolarisDiagnostics.class);
       PolarisAuthorizer authorizer = Mockito.mock(PolarisAuthorizer.class);
-      FileIOConfiguration fileIOConfiguration = Mockito.mock(FileIOConfiguration.class);
 
       // Application level
       PolarisStorageIntegrationProviderImpl storageIntegrationProvider =
@@ -172,6 +172,8 @@ public record TestServices(
           metaStoreManagerFactory.getOrCreateMetaStoreManager(realmContext);
       UserSecretsManager userSecretsManager =
           userSecretsManagerFactory.getOrCreateUserSecretsManager(realmContext);
+
+      FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
 
       FileIOFactory fileIOFactory =
           fileIOFactorySupplier.apply(

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/TestServices.java
@@ -173,7 +173,7 @@ public record TestServices(
       UserSecretsManager userSecretsManager =
           userSecretsManagerFactory.getOrCreateUserSecretsManager(realmContext);
 
-      FileIOConfiguration fileIOConfiguration = new FileIOConfiguration() {};
+      FileIOConfiguration fileIOConfiguration = new TestFileIOConfiguration() {};
 
       FileIOFactory fileIOFactory =
           fileIOFactorySupplier.apply(

--- a/service/common/src/testFixtures/java/org/apache/polaris/service/catalog/io/MeasuredFileIOFactory.java
+++ b/service/common/src/testFixtures/java/org/apache/polaris/service/catalog/io/MeasuredFileIOFactory.java
@@ -56,10 +56,14 @@ public class MeasuredFileIOFactory implements FileIOFactory {
   public MeasuredFileIOFactory(
       RealmEntityManagerFactory realmEntityManagerFactory,
       MetaStoreManagerFactory metaStoreManagerFactory,
-      PolarisConfigurationStore configurationStore) {
+      PolarisConfigurationStore configurationStore,
+      FileIOConfiguration fileIOConfiguration) {
     defaultFileIOFactory =
         new DefaultFileIOFactory(
-            realmEntityManagerFactory, metaStoreManagerFactory, configurationStore);
+            realmEntityManagerFactory,
+            metaStoreManagerFactory,
+            configurationStore,
+            fileIOConfiguration);
   }
 
   @Override


### PR DESCRIPTION
This draft PR illustrates how we might configure DefaultFileIOFactory so that HadoopFileIO is not usable.